### PR TITLE
New data transfer nodes at CC-IN2P3

### DIFF
--- a/manifests/in2p3-cosmo/configmap/ingest.yaml
+++ b/manifests/in2p3-cosmo/configmap/ingest.yaml
@@ -5,10 +5,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: cosmoDC2_v1.1.4_image/
     qserv:

--- a/manifests/in2p3-dc2_dr6_object_v2/configmap/ingest.yaml
+++ b/manifests/in2p3-dc2_dr6_object_v2/configmap/ingest.yaml
@@ -5,10 +5,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: dc2_dr6_object_v2/
     qserv:

--- a/manifests/in2p3-dp0.2/configmap/ingest.yaml
+++ b/manifests/in2p3-dp0.2/configmap/ingest.yaml
@@ -12,10 +12,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: stable/idf-dp0.2-catalog-chunked/PREOPS-905
     qserv:

--- a/manifests/in2p3-dp01_dc2/configmap/ingest.yaml
+++ b/manifests/in2p3-dp01_dc2/configmap/ingest.yaml
@@ -5,10 +5,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: dp01_dc2_catalogs/
     qserv:

--- a/manifests/in2p3-skysim5000/configmap/ingest.yaml
+++ b/manifests/in2p3-skysim5000/configmap/ingest.yaml
@@ -5,10 +5,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: skysim5000_v1.1.1_parquet/
     qserv:

--- a/manifests/in2p3-wfd/configmap/ingest.yaml
+++ b/manifests/in2p3-wfd/configmap/ingest.yaml
@@ -5,10 +5,9 @@ ingest:
         # TODO Add support for webdav protocol
         # Use file:// as first element in list when using local data
         servers:
-            - https://ccnetlsst01.in2p3.fr:65101
-            - https://ccnetlsst02.in2p3.fr:65101
-            - https://ccnetlsst03.in2p3.fr:65101
-            - https://ccnetlsst04.in2p3.fr:65101
+            - https://ccnetlsst10.in2p3.fr:65101
+            - https://ccnetlsst11.in2p3.fr:65101
+            - https://ccnetlsst12.in2p3.fr:65101
         # Path on server where input data is available
         path: dc2_object_run2_2i_dr6_wfd/
     qserv:


### PR DESCRIPTION
Three new DTN are in place at CC-In2P3 to serve data 

https://ccnetlsst10.in2p3.fr:65101
https://ccnetlsst11.in2p3.fr:65101
https://ccnetlsst12.in2p3.fr:65101

I updated the ingest config to use the new machines instead of the old one ccnetlsst**0**{1,4}